### PR TITLE
Update docs to use newer plugin name and vars format

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,13 +9,13 @@ docker run -it -v $(pwd)/safedns.ini:/safedns.ini -v /etc/letsencrypt:/etc/letse
 
 ```bash
 apt install certbot python3-pip
-pip3 install certbot-dns-safedns
+pip3 install --upgrade certbot-dns-safedns
 ```
 
 ## Execution
 
 ```bash
-certbot certonly --authenticator certbot-dns-safedns:dns_safedns
+certbot certonly --authenticator dns_safedns
 ```
 
 > **Warning**: certbot might tell you that it doesn't have permissions to write to its log file. However, if you run certbot as sudo, you won't have access to the safedns plugin if you didn't install the plugin as sudo.
@@ -29,8 +29,8 @@ Could not choose appropriate plugin: The requested dns_safedns plugin does not a
 To get around this just do:
 
 ```bash
-sudo pip3 install certbot-dns-safedns
-sudo certbot certonly --authenticator certbot-dns-safedns:dns_safedns
+sudo pip3 install --upgrade certbot-dns-safedns
+sudo certbot certonly --authenticator dns_safedns
 ```
 
 If you get any python cryptography errors, such as:
@@ -47,16 +47,16 @@ sudo pip install --upgrade pyopenssl
 
 ### Credentials and Config Options
 
-Use of this plugin requires a configuration file containing SafeDNS API credentials, obtained from your MyUKFast [account page](https://my.ukfast.co.uk/applications/index.php). See also the [SafeDNS API](https://developers.ukfast.io/documentation/safedns) documentation.
+Use of this plugin can be simplified by using a configuration file containing SafeDNS API credentials, obtained from your MyUKFast [account page](https://my.ukfast.co.uk/applications/index.php). See also the [SafeDNS API](https://developers.ukfast.io/documentation/safedns) documentation.
 
-An example ``credentials.ini`` file:
+An example ``safedns.ini`` file:
 
 ```ini
-certbot_dns_safedns:dns_safedns_auth_token = 0123456789abcdef0123456789abcdef01234567
-certbot_dns_safedns:dns_safedns_propagation_seconds = 20
+dns_safedns_auth_token = 0123456789abcdef0123456789abcdef01234567
+dns_safedns_propagation_seconds = 20
 ```
 
-The path to this file can be provided interactively or using the `--certbot-dns-safedns:dns_safedns-credentials` command-line argument. Certbot records the path to this file for use during renewal, but does not store the file's contents.
+The path to this file can be provided interactively or using the `--dns_safedns-credentials` command-line argument. Certbot records the path to this file for use during renewal, but does not store the file's contents.
 
 > **CAUTION:** You should protect these API credentials as you would the password to your MyUKFast account. Users who can read this file can use these credentials to issue arbitrary API calls on your behalf. Users who can cause Certbot to run using these credentials can complete a ``dns-01`` challenge to acquire new certificates or revoke existing certificates for associated domains, even if those domains aren't being managed by this server.
 
@@ -68,10 +68,9 @@ To acquire a single certificate for both `example.com` and `*.example.com`, wait
 
 ```bash
 certbot certonly \
-  --authenticator certbot-dns-safedns:dns_safedns \
-  --certbot-dns-safedns:dns_safedns-credentials ~/.secrets/certbot/safedns.ini \
-  --certbot-dns-safedns:dns_safedns-propagation-seconds 900 \
-  --server https://acme-v02.api.letsencrypt.org/directory \
+  --authenticator dns_safedns \
+  --dns_safedns-credentials ~/.secrets/certbot/safedns.ini \
+  --dns_safedns-propagation-seconds 900 \
   -d 'example.com' \
   -d '*.example.com'
 ```


### PR DESCRIPTION
This MR updates the documentation to reflect the (simplified) renaming of plugins that occurred in Certbot.

Further info can be found here: <https://docs.ukfast.co.uk/domains/safedns/certbotplugin.html>