### PR TITLE
Make releases only be created on push to master

### DIFF
--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -30,6 +30,7 @@ jobs:
           version-fragment: 'bug'
         
       - name: Create Release
+        if: github.event_name == 'push'
         id: create_release
         uses: actions/create-release@v1
         env:
@@ -41,6 +42,7 @@ jobs:
           prerelease: false
           
       - name: Build and deploy
+        if: github.event_name == 'push'
         run: |
           echo v${{ steps.bump_version.outputs.next-version }} > VERSION
           pip install twine


### PR DESCRIPTION
This should stop trying to create releases on a submitted PR, and so stop the CI failing like this:
* https://github.com/ukfast/certbot-dns-safedns/pull/43/checks
* https://github.com/ukfast/certbot-dns-safedns/runs/4660330013?check_suite_focus=true
* https://github.com/ukfast/certbot-dns-safedns/runs/4660304071?check_suite_focus=true