### PR TITLE
Update SafeDNS arguments passed to Certbot

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,4 +3,4 @@ FROM python:latest
 RUN apt update && apt install certbot -y
 RUN pip install certbot-dns-safedns
 
-ENTRYPOINT ["certbot", "--authenticator", "certbot-dns-safedns:dns_safedns", "--certbot-dns-safedns:dns_safedns-credentials", "/etc/letsencrypt/safedns.ini"]
+ENTRYPOINT ["certbot", "--authenticator", "dns_safedns", "--dns_safedns-credentials", "/etc/letsencrypt/safedns.ini"]


### PR DESCRIPTION
When using the original options, this warning is emitted:

`Plugin legacy name certbot-dns-safedns:dns_safedns may be removed in a future version. Please use dns_safedns instead.`