### PR TITLE
Improve Docker image size

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,12 @@
-FROM python:latest
+FROM python:3.10-alpine AS build
 
-RUN apt update && apt install certbot -y
-RUN pip install certbot-dns-safedns
+RUN apk add --no-cache py3-pip alpine-sdk libffi-dev
+RUN python3 -m venv /opt/venv
+ENV PATH="/opt/venv/bin:$PATH"
+RUN pip install certbot certbot-dns-safedns
+
+FROM python:3.10-alpine
+COPY --from=build /opt/venv /opt/venv
+ENV PATH="/opt/venv/bin:$PATH"
 
 ENTRYPOINT ["certbot", "--authenticator", "dns_safedns", "--dns_safedns-credentials", "/etc/letsencrypt/safedns.ini"]


### PR DESCRIPTION
Docker image size currently weighs in at around 990MB using the full-fat Python image.

This switches it to use the Python Alpine image and adds a build step to reduce the final image size down to around 87MB.