### PR TITLE
Add Docker Hub publish step to release workflow

### DIFF
--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -56,3 +56,31 @@ jobs:
         env:
           UV_PUBLISH_USERNAME: ${{ secrets.TWINE_USERNAME }}
           UV_PUBLISH_PASSWORD: ${{ secrets.TWINE_PASSWORD }}
+
+      - name: Set up QEMU
+        if: github.event_name == 'push'
+        uses: docker/setup-qemu-action@v4.2.0
+
+      - name: Set up Docker Buildx
+        if: github.event_name == 'push'
+        uses: docker/setup-buildx-action@v4.2.0
+
+      - name: Log in to Docker Hub
+        if: github.event_name == 'push'
+        uses: docker/login-action@v4.4.0
+        with:
+          username: ansdevops
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Build and push Docker image
+        if: github.event_name == 'push'
+        uses: docker/build-push-action@v7.3.0
+        with:
+          context: .
+          push: true
+          platforms: linux/amd64,linux/arm64
+          build-args: |
+            CERTBOT_DNS_SAFEDNS_VERSION=${{ steps.bump_version.outputs.next-version }}
+          tags: |
+            ans-group/certbot-dns-safedns:v${{ steps.bump_version.outputs.next-version }}
+            ans-group/certbot-dns-safedns:latest

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,12 @@
 FROM python:3.13-alpine AS build
 COPY --from=ghcr.io/astral-sh/uv:latest /uv /usr/local/bin/uv
 
+ARG CERTBOT_DNS_SAFEDNS_VERSION=""
+
 RUN apk add --no-cache alpine-sdk libffi-dev
 RUN uv venv /opt/venv
 ENV PATH="/opt/venv/bin:$PATH"
-RUN uv pip install --python /opt/venv/bin/python certbot certbot-dns-safedns
+RUN uv pip install --python /opt/venv/bin/python certbot "certbot-dns-safedns${CERTBOT_DNS_SAFEDNS_VERSION:+==${CERTBOT_DNS_SAFEDNS_VERSION}}"
 
 FROM python:3.13-alpine
 COPY --from=build /opt/venv /opt/venv


### PR DESCRIPTION
## Summary
Currently the release workflow (tag.yml) publishes the Python package to PyPI on push to master/main, but nothing builds or publishes the Docker image; it's done manually today.

This adds a Docker Hub publish step to the same release job:

- Builds and pushes a multi-arch (linux/amd64, linux/arm64) image to ans-group/certbot-dns-safedns on Docker Hub, tagged with the bumped semver version (e.g. v0.1.52) and latest.
- Runs after the PyPI publish step, and pins the image build to the exact version just published via a new CERTBOT_DNS_SAFEDNS_VERSION build-arg on the Dockerfile, avoiding a race with PyPI index propagation when installing certbot-dns-safedns from PyPI (default build-arg is empty, so a plain docker build still installs latest, unaffected).
- Authenticates to Docker Hub as ansdevops using the existing DOCKERHUB_TOKEN repo secret.

All new GitHub Actions are pinned to their current latest releases:
- docker/setup-qemu-action@v4.2.0
- docker/setup-buildx-action@v4.2.0
- docker/login-action@v4.4.0
- docker/build-push-action@v7.3.0

## Testing
- Validated tag.yml YAML parses correctly.
- Built the Dockerfile locally both without a version pin (installs latest from PyPI) and with build-arg CERTBOT_DNS_SAFEDNS_VERSION=0.1.51 (confirmed certbot-dns-safedns==0.1.51 is installed).
