### PR TITLE
Wait for PyPI propagation before building Docker image

### DIFF
--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -57,6 +57,23 @@ jobs:
           UV_PUBLISH_USERNAME: ${{ secrets.TWINE_USERNAME }}
           UV_PUBLISH_PASSWORD: ${{ secrets.TWINE_PASSWORD }}
 
+      - name: Wait for PyPI package availability
+        if: github.event_name == 'push'
+        run: |
+          version="${{ steps.bump_version.outputs.next-version }}"
+          for attempt in $(seq 1 30); do
+            # Query the same simple-repository index uv/pip use to resolve packages,
+            # rather than the JSON API, since that's what actually needs to be in sync.
+            if curl -fsS "https://pypi.org/simple/certbot-dns-safedns/" | grep -q "certbot_dns_safedns-${version}[.-]"; then
+              echo "certbot-dns-safedns==${version} is available on PyPI"
+              exit 0
+            fi
+            echo "Attempt ${attempt}: certbot-dns-safedns==${version} not yet available on PyPI, waiting..."
+            sleep 10
+          done
+          echo "Timed out waiting for certbot-dns-safedns==${version} to become available on PyPI" >&2
+          exit 1
+
       - name: Set up QEMU
         if: github.event_name == 'push'
         uses: docker/setup-qemu-action@v4.2.0


### PR DESCRIPTION
## Summary
Root cause of https://github.com/ans-group/certbot-dns-safedns/actions/runs/29420466131/job/87369464954: the Docker build step failed with:

```
× No solution found when resolving dependencies:
╰─▶ Because there is no version of certbot-dns-safedns==0.1.53 ...
```

`uv publish` returns as soon as the upload completes, but PyPI's index doesn't update instantly — the Docker build (which pins to the just-published version via the `CERTBOT_DNS_SAFEDNS_VERSION` build-arg from #85) ran ~20s later and PyPI hadn't caught up yet.

## Fix
Adds a "Wait for PyPI package availability" step between the PyPI publish and the Docker build. It polls `https://pypi.org/simple/certbot-dns-safedns/` (the same simple-repository index uv/pip use for resolution) every 10s, up to 5 minutes, for the just-published version's filename to appear, before continuing to the Docker build/push steps.

## Testing
- Confirmed the grep pattern matches an existing release's filenames from the real simple index response, and doesn't match a bogus/nonexistent version.
- Validated `tag.yml` YAML parses correctly.
